### PR TITLE
examples: add interlayer_helpers (NLayerCalculator / MACEWCalculator)

### DIFF
--- a/examples/interlayer_helpers/README.md
+++ b/examples/interlayer_helpers/README.md
@@ -1,0 +1,32 @@
+# interlayer_helpers
+
+Helper modules that provide the stacked intra-layer + inter-layer ASE
+calculator used by `mlip_phonon_scattering`'s interlayer mode.
+
+## Contents
+
+- `n_layer.py` — defines `NLayerCalculator`, an ASE calculator that re-splits a
+  passed structure by `atoms.arrays['atom_types']` value ranges and sums the
+  per-layer (intra-layer) and adjacent-pair (inter-layer) contributions.
+- `macewrapper.py` — defines `MACEWCalculator`, a MACE wrapper that binds to a
+  fixed atom subset (storing its `atom_types` / `layer_ids`) and evaluates
+  either an intra-layer or inter-layer model.
+
+## Note on the `ittnotify` preload
+
+`macewrapper.py` contains an optional `ittnotify` preload that guards against
+PyTorch builds whose oneDNN JIT profiling references undefined `iJIT_*` symbols
+at `import torch`. It is a **no-op** when no such library is found, and it is
+**not needed** on the NERSC `pytorch/2.11.0` module (torch 2.11.0+cu129 imports
+cleanly and a full MACE evaluation runs without any stub), so no stub binary is
+shipped here. If you ever hit an `undefined symbol: __itt_*` error on a different
+PyTorch build, build the tiny stub from `mlip_phonon_scattering/ittnotify_stub/`
+(`make`) and place the resulting `libittnotify.so` in an `ittnotify_stub/`
+directory next to `macewrapper.py`.
+
+## Provenance
+
+`n_layer.py` and `macewrapper.py` were copied verbatim from the (non-git)
+`mace-interlayer-example` working directory. Put this folder on `PYTHONPATH`
+(via `load_mace_phonon_env.sh`) so that `from macewrapper import MACEWCalculator`
+and `from n_layer import NLayerCalculator` resolve at runtime.

--- a/examples/interlayer_helpers/macewrapper.py
+++ b/examples/interlayer_helpers/macewrapper.py
@@ -1,0 +1,292 @@
+from ase.calculators.calculator import (
+    Calculator,
+    CalculatorError,
+    CalculatorSetupError,
+    all_changes,
+)
+from ase.data import atomic_masses, atomic_numbers, chemical_symbols
+from typing import List, Dict, Union
+from pathlib import Path
+from ase.atoms import Atoms
+import numpy as np
+import ctypes
+
+
+def _preload_ijit_notify() -> None:
+    """
+    PyTorch builds that include oneDNN JIT profiling may reference iJIT_* symbols
+    without linking an ittnotify library. Preload a provider (or a local stub)
+    so importing torch doesn't fail with an undefined symbol.
+    """
+    for lib in ("libiJITProfiling.so", "libittnotify.so", "libjitprofiling.so"):
+        try:
+            ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
+            return
+        except OSError:
+            pass
+
+    stub_dir = Path(__file__).resolve().parent / "ittnotify_stub"
+    for p in (
+        stub_dir / "libittnotify.so",
+        stub_dir / "libittnotify_stub.so",
+        stub_dir / "libiJITProfiling.so",
+    ):
+        if p.exists():
+            ctypes.CDLL(str(p), mode=ctypes.RTLD_GLOBAL)
+            return
+
+
+_preload_ijit_notify()
+import torch
+from mace.calculators import MACECalculator
+from mace.calculators.mace import full_3x3_to_voigt_6_stress
+
+
+class CompatMACECalculator(MACECalculator):
+    def _call_model(self, model, batch_dict, compute_stress, oeq_compile):
+        model_kwargs = {
+            "compute_stress": compute_stress,
+            "training": self.use_compile and not oeq_compile,
+            "compute_edge_forces": self.compute_atomic_stresses,
+            "compute_atomic_stresses": self.compute_atomic_stresses,
+        }
+        try:
+            return model(batch_dict, **model_kwargs)
+        except RuntimeError as exc:
+            if "Unknown keyword argument" not in str(exc):
+                raise
+            # Older TorchScript MACE models do not accept the newer atomic-stress
+            # kwargs used by mace-torch 0.3.16. Forces only need this older call.
+            model_kwargs.pop("compute_edge_forces", None)
+            model_kwargs.pop("compute_atomic_stresses", None)
+            return model(batch_dict, **model_kwargs)
+
+    # pylint: disable=dangerous-default-value
+    def calculate(self, atoms=None, properties=None, system_changes=all_changes):
+        Calculator.calculate(self, atoms)
+
+        batch_base = self._atoms_to_batch(atoms)
+        num_real_atoms = len(atoms)
+        is_padded = self.pad_num_atoms > 0 or self.pad_num_edges > 0
+        stress_properties = {"stress", "stresses", "virials"}
+        compute_stress = (
+            self.model_type in ["MACE", "EnergyDipoleMACE", "PolarMACE"]
+            and properties is not None
+            and any(prop in stress_properties for prop in properties)
+        )
+        oeq_compile = self.use_compile and self._enable_oeq
+
+        ret_tensors = None
+        node_e0 = None
+        for i, model in enumerate(self.models):
+            batch = self._clone_batch(batch_base)
+            model_dtype = next(model.parameters()).dtype
+            for key in batch.keys:
+                value = batch[key]
+                if torch.is_tensor(value) and torch.is_floating_point(value):
+                    batch[key] = value.to(dtype=model_dtype)
+            batch_dict = batch.to_dict()
+
+            if oeq_compile and compute_stress:
+                positions = batch_dict["positions"]
+                num_graphs = int(batch_dict["ptr"].numel() - 1)
+                displacement = torch.zeros(
+                    (num_graphs, 3, 3),
+                    dtype=positions.dtype,
+                    device=positions.device,
+                )
+                displacement = displacement + positions.sum() * 0.0
+                batch_dict["displacement"] = displacement
+
+            out = self._call_model(model, batch_dict, compute_stress, oeq_compile)
+            if is_padded:
+                out = self._slice_real_outputs(out, num_real_atoms)
+            if i == 0:
+                ret_tensors, node_e0 = self._create_result_tensors(
+                    self.num_models, num_real_atoms, batch, out
+                )
+            for key, val in ret_tensors.items():
+                if out.get(key) is not None:
+                    val[i] = out[key].detach()
+
+        self.results = {}
+        scalar_tensors = set(["energy"])
+        results_store_ensemble = set(["energy", "forces", "stress", "dipole"])
+        results_map = [
+            ("energy", "energy", self.energy_units_to_eV),
+            ("node_energy", "node_energy", self.energy_units_to_eV),
+            ("forces", "forces", self.energy_units_to_eV / self.length_units_to_A),
+            ("stress", "stress", self.energy_units_to_eV / self.length_units_to_A**3),
+            (
+                "stresses",
+                "atomic_stresses",
+                self.energy_units_to_eV / self.length_units_to_A**3,
+            ),
+            (
+                "virials",
+                "atomic_virials",
+                self.energy_units_to_eV / self.length_units_to_A**3,
+            ),
+            ("dipole", "dipole", 1.0),
+            ("charges", "charges", 1.0),
+            ("polarizability", "polarizability", 1.0),
+            ("polarizability_sh", "polarizability_sh", 1.0),
+        ]
+        for results_key, ret_key, unit_conv in results_map:
+            if ret_tensors.get(ret_key) is not None:
+                data = torch.mean(ret_tensors[ret_key], dim=0).cpu()
+                if ret_key in scalar_tensors:
+                    data = data.item()
+                else:
+                    data = data.numpy()
+                self.results[results_key] = data * unit_conv
+
+                if self.num_models > 1 and results_key in results_store_ensemble:
+                    data = ret_tensors[results_key].cpu().numpy()
+                    data *= unit_conv
+                    self.results[results_key + "_comm"] = data
+
+                    data = torch.var(
+                        ret_tensors[results_key], dim=0, unbiased=False
+                    ).cpu()
+                    if ret_key in scalar_tensors:
+                        data = data.item()
+                    else:
+                        data = data.numpy()
+                    data *= unit_conv
+                    self.results[results_key + "_var"] = data
+
+        if self.results.get("energy") is not None:
+            self.results["free_energy"] = self.results["energy"]
+        if self.results.get("node_energy") is not None:
+            self.results["energies"] = self.results["node_energy"].copy()
+            self.results["node_energy"] -= node_e0
+        if self.results.get("stress") is not None:
+            self.results["stress"] = full_3x3_to_voigt_6_stress(self.results["stress"])
+        if self.results.get("stresses") is not None:
+            self.results["stresses"] = np.asarray(
+                [
+                    full_3x3_to_voigt_6_stress(stress)
+                    for stress in self.results["stresses"]
+                ]
+            )
+
+
+class InterlayerCompatMACECalculator(CompatMACECalculator):
+    """MACE calculator variant that keeps only cross-layer graph edges."""
+
+    def __init__(self, *args, **kwargs):
+        arrays_keys = dict(kwargs.pop("arrays_keys", {}) or {})
+        arrays_keys.setdefault("layer_ids", "layer_ids")
+        super().__init__(*args, arrays_keys=arrays_keys, **kwargs)
+
+    def _atoms_to_batch(self, atoms):
+        batch = super()._atoms_to_batch(atoms)
+        layer_ids = batch["layer_ids"].view(-1)
+        edge_index = batch["edge_index"]
+        edge_mask = layer_ids[edge_index[0]] != layer_ids[edge_index[1]]
+        num_edges = edge_index.shape[1]
+
+        batch["edge_index"] = edge_index[:, edge_mask]
+        for key in list(batch.keys):
+            value = batch[key]
+            if (
+                key != "edge_index"
+                and torch.is_tensor(value)
+                and value.ndim > 0
+                and value.shape[0] == num_edges
+            ):
+                batch[key] = value[edge_mask]
+
+        return batch
+
+
+class MACEWCalculator(Calculator):
+    # Define the properties that the calculator can handle
+    implemented_properties = ["energy", "energies", "forces", "free_energy"]
+
+    def __init__(self,
+                 atoms: Atoms,
+                 layer_symbols: list[str],
+                 model_file: str,
+                 device='cpu',
+                 default_dtype='float32',
+                 is_interlayer_calc=False,
+                 **kwargs):
+        """
+        Initializes the MACEWCalculator with a given set of atoms, layer symbols, model file, and device.
+
+        :param atoms: ASE atoms object.
+        :param layer_symbols: List of symbols representing different layers in the structure.
+        :param model_file: Path to the file containing the trained model.
+        :param device: Device to run the calculations on, default is 'cpu'.
+        :param default_dtype: Default data type for calculations ('float32' or 'float64').
+        :param kwargs: Additional keyword arguments for the base class.
+        """
+        self.atoms = atoms  # ASE atoms object
+        self.atom_types = atoms.arrays['atom_types']  # Extract atom types from atoms object
+        self.device = device  # Device for computations
+        self.layer_ids = atoms.arrays['layer_ids']
+        self.is_interlayer_calc = is_interlayer_calc
+        # Flatten the layer symbols list
+        self.layer_symbols = [symbol for sublist in layer_symbols for symbol in (sublist if isinstance(sublist, list) else [sublist])]
+
+        # Determine unique atom types and their indices
+        unique_types, inverse = np.unique(self.atom_types, return_inverse=True)
+
+        # Map atom types to their relative positions in the unique_types array
+        self.relative_layer_types = inverse
+
+        # Ensure the number of unique atom types matches the number of layer symbols provided
+        if len(unique_types) != len(self.layer_symbols):
+            raise ValueError("Mismatch between the number of atom types and provided layer symbols.")
+
+        # Initialize the MACE calculator
+        mace_calculator_cls = InterlayerCompatMACECalculator if is_interlayer_calc else CompatMACECalculator
+        self.mace_calc = mace_calculator_cls(
+            model_paths=model_file,
+            device=device,
+            default_dtype=default_dtype,
+            **kwargs
+        )
+
+        # Initialize the base Calculator class with any additional keyword arguments
+        Calculator.__init__(self, **kwargs)
+
+    def calculate(self,
+                 atoms: Atoms = None,
+                 properties=None,
+                 system_changes=all_changes):
+        """
+        Performs the calculation for the given atoms and properties.
+
+        :param atoms: ASE atoms object to calculate properties for.
+        :param properties: List of properties to calculate. If None, uses implemented_properties.
+        :param system_changes: List of changes that have been made to the system since last calculation.
+        """
+        # Default to implemented properties if none are specified
+        if properties is None:
+            properties = self.implemented_properties
+
+        # Create a temporary copy of the atoms object
+        tmp_atoms = atoms.copy()[:]
+        tmp_atoms.calc = None  # Remove any attached calculator
+
+        # Backup original atomic numbers and set new atomic numbers based on relative layer types
+        original_atom_numbers = tmp_atoms.numbers.copy()
+        # tmp_atoms.set_atomic_numbers(self.relative_layer_types + 1)
+        tmp_atoms.arrays['atom_types'] = self.relative_layer_types
+        tmp_atoms.arrays['layer_ids'] = self.layer_ids
+
+        # Set the MACE calculator for the temporary atoms
+        tmp_atoms.calc = self.mace_calc
+
+        # Calculate properties using MACE
+        self.mace_calc.calculate(tmp_atoms, properties, system_changes)
+
+        # Restore the original atomic numbers and types
+        tmp_atoms.set_atomic_numbers(original_atom_numbers)
+        tmp_atoms.arrays['atom_types'] = self.atom_types
+
+        # Copy results from MACE calculator
+        self.results = self.mace_calc.results.copy() 

--- a/examples/interlayer_helpers/n_layer.py
+++ b/examples/interlayer_helpers/n_layer.py
@@ -1,0 +1,248 @@
+# from ase.calculators.calculator import (
+#     Calculator,
+#     CalculatorError,
+#     CalculatorSetupError,
+#     all_changes,
+# )
+# from ase import Atoms
+# import numpy as np
+
+
+# class NLayerCalculator(Calculator):
+#     implemented_properties = ['energy', 'energies', 'forces']  # Define the properties this calculator can compute
+    
+#     def __init__(self,
+#                  atoms,
+#                  intralayer_calculators: list[Calculator],
+#                  interlayer_calculators: list[Calculator],
+#                  layer_symbols: list[str],
+#                  **kwargs):
+#         Calculator.__init__(self, **kwargs)
+#         self.intra_calc_list = intralayer_calculators
+#         self.inter_calc_list = interlayer_calculators
+#         self.layer_symbols = layer_symbols
+        
+
+#     def calculate(self,
+#                   atoms: Atoms,
+#                   properties=None,
+#                   system_changes=all_changes):
+        
+#         if properties is None:
+#             properties = self.implemented_properties
+
+#         self.atoms_layer_list = []
+
+#         Calculator.calculate(self, atoms, properties, system_changes)
+
+#         self.get_atoms_layer_list(self.atoms)
+
+#         self.results['layer_energy'] = np.zeros((len(self.intra_calc_list), len(self.intra_calc_list)))
+#         self.results['layer_forces'] = np.zeros((len(self.intra_calc_list),
+#                                                  len(self.intra_calc_list),
+#                                                  atoms.get_global_number_of_atoms(), 3))
+#         # self.results['layer_energies'] = np.zeros((len(self.intra_calc_list),
+#         #                                            len(self.intra_calc_list),
+#         #                                            atoms.get_global_number_of_atoms()))
+#         for layer_index_i in range(len(self.intra_calc_list)):
+#             for layer_index_j in range(len(self.intra_calc_list)):    
+#                 if layer_index_i == layer_index_j:
+#                     self.calculate_intralayer(atoms, layer=layer_index_i)
+#                 elif layer_index_i < layer_index_j:
+#                     self.calculate_interlayer(atoms,
+#                                               layer_1=layer_index_i,
+#                                               layer_2=layer_index_j)
+#                 elif layer_index_i > layer_index_j:
+#                     self.results['layer_energy'][layer_index_i, layer_index_j] = 0
+#                     self.results['layer_forces'][layer_index_i, layer_index_j] = 0
+#                     # self.results['layer_energies'][layer_index_i, layer_index_j] = self.results['layer_energies'][layer_index_j, layer_index_i]
+#         self.results["energy"] = self.results["layer_energy"].sum()
+#         self.results["forces"] = self.results["layer_forces"].sum(axis=(0,1))
+#         # self.results['energies'] = 1./2 * (self.results["layer_energies"].sum(axis=(0,1)) + self.results["layer_energies"].trace(axis1 = 0, axis2 = 1))
+     
+#     def calculate_intralayer(self, atoms, layer: int):
+
+#         if layer <= len(self.intra_calc_list):
+#             calc = self.intra_calc_list[layer]
+#             atoms_L = self.atoms_layer_list[layer]
+#         else:
+#             raise ValueError("layer number muls")
+        
+#         atoms_L.calc = calc
+#         atoms_L.calc.calculate(atoms_L)
+
+#         lower_layers_num_atoms = sum([len(layer_atoms) for layer_atoms in self.atoms_layer_list[:(layer)]])
+#         layer_atom_indices = [lower_layers_num_atoms,
+#                               lower_layers_num_atoms + len(self.atoms_layer_list[layer])]
+        
+#         self.results[f"layer_energy"][layer,layer] = atoms_L.calc.results['energy']
+#         self.results[f"layer_forces"][layer,layer][layer_atom_indices[0]:layer_atom_indices[1]] = atoms_L.calc.results['forces']
+#         # self.results['layer_energies'][layer,layer][layer_atom_indices[0]:layer_atom_indices[1]] = atoms_L.calc.results['energies']
+
+#     def calculate_interlayer(self, atoms, layer_1: int, layer_2: int):
+#         # JDG: code only considers adjacent layers
+#         if layer_2 > layer_1 + 1:
+#             return 0
+        
+#         atoms_L = self.atoms_layer_list[layer_1].copy() + self.atoms_layer_list[layer_2].copy()
+#         calc = self.inter_calc_list[layer_1]
+#         atoms_L.calc = calc
+#         atoms_L.calc.calculate(atoms_L)
+
+#         lower_layers_num_atoms = sum([len(layer_atoms) for layer_atoms in self.atoms_layer_list[:(layer_1)]])
+#         layer_atom_indices = [lower_layers_num_atoms,
+#                               lower_layers_num_atoms + len(self.atoms_layer_list[layer_1]) + len(self.atoms_layer_list[layer_2])]
+        
+#         self.results["layer_energy"][layer_1,layer_2] = atoms_L.calc.results['energy']
+#         self.results["layer_forces"][layer_1,layer_2][layer_atom_indices[0]:layer_atom_indices[1]] = atoms_L.calc.results['forces']
+#         # self.results['layer_energies'][layer_1,layer_2][layer_atom_indices[0]:layer_atom_indices[1]] = atoms_L.get_potential_energies()
+
+#     def get_atoms_layer_list(self, atoms):
+
+#         for layer in range(len(self.intra_calc_list)):
+        
+#             lower_layer_num_atoms = sum([len(layer_atoms) for layer_atoms in self.layer_symbols[:(layer)]])
+#             layer_atom_indices = [lower_layer_num_atoms,
+#                                   lower_layer_num_atoms + len(self.layer_symbols[layer]) - 1]
+            
+#             atoms_L = atoms.copy()[np.logical_and(atoms.arrays["atom_types"] <= layer_atom_indices[1],
+#                                                   atoms.arrays["atom_types"] >= layer_atom_indices[0])]
+            
+#             self.atoms_layer_list.append(atoms_L)
+
+
+from ase.calculators.calculator import Calculator, all_changes
+from ase import Atoms
+import numpy as np
+
+class NLayerCalculator(Calculator):
+    """
+    A calculator designed to handle calculations for materials with multiple layers, 
+    using separate intra-layer and inter-layer calculators.
+    """
+    # Properties that the calculator can compute
+    implemented_properties = ['energy', 'energies', 'forces']
+    
+    def __init__(self, atoms, intralayer_calculators: list[Calculator], interlayer_calculators: list[Calculator], layer_symbols: list[str], **kwargs):
+        """
+        Initializes the NLayerCalculator.
+
+        :param atoms: The ASE Atoms object representing the system.
+        :param intralayer_calculators: A list of calculators for intra-layer interactions.
+        :param interlayer_calculators: A list of calculators for inter-layer interactions.
+        :param layer_symbols: A list of symbols (or any identifier) for each layer in the system.
+        """
+        super().__init__(**kwargs)  # Initialize the parent Calculator class
+        self.intra_calc_list = intralayer_calculators  # List of intra-layer calculators
+        self.inter_calc_list = interlayer_calculators  # List of inter-layer calculators
+        self.layer_symbols = layer_symbols  # Symbols for different layers
+
+    def calculate(self, atoms: Atoms, properties=None, system_changes=all_changes):
+        """
+        Performs the calculation for the specified atoms.
+
+        :param atoms: The ASE Atoms object to calculate properties for.
+        :param properties: The list of properties to calculate. Uses implemented_properties by default.
+        :param system_changes: The list of changes that have been made to the system since the last calculation.
+        """
+        # Set to default properties if none are specified
+        if properties is None:
+            properties = self.implemented_properties
+
+        # Initialize or reset the layer list for atoms
+        self.atoms_layer_list = []
+
+        # Perform the base class calculation (primarily for handling system changes)
+        super().calculate(atoms, properties, system_changes)
+
+        # Populate the atoms_layer_list based on the provided atoms and layer_symbols
+        self.get_atoms_layer_list(atoms)
+
+        # Initialize result arrays for energies and forces
+        num_layers = len(self.intra_calc_list)
+        num_atoms = atoms.get_global_number_of_atoms()
+        self.results['layer_energy'] = np.zeros((num_layers, num_layers))
+        self.results['layer_forces'] = np.zeros((num_layers, num_layers, num_atoms, 3))
+
+        # Calculate intra-layer and inter-layer interactions
+        for i in range(num_layers):
+            for j in range(num_layers):    
+                if i == j:
+                    # Intra-layer calculation
+                    self.calculate_intralayer(atoms, layer=i)
+                elif i < j:
+                    # Inter-layer calculation for layers i and j
+                    self.calculate_interlayer(atoms, layer_1=i, layer_2=j)
+                else:
+                    # No calculation needed, ensure energy and forces are set to zero
+                    self.results['layer_energy'][i, j] = 0
+                    self.results['layer_forces'][i, j] = 0
+
+        # Aggregate the energies and forces from all layers to the top-level results
+        self.results["energy"] = self.results["layer_energy"].sum()
+        self.results["forces"] = self.results["layer_forces"].sum(axis=(0, 1))
+
+    def calculate_intralayer(self, atoms, layer: int):
+        """
+        Calculates intra-layer properties for a specified layer.
+
+        :param atoms: The ASE Atoms object.
+        :param layer: The index of the layer for intra-layer calculation.
+        """
+        if layer < len(self.intra_calc_list):
+            # Assign the corresponding calculator and atoms for the layer
+            calc = self.intra_calc_list[layer]
+            atoms_L = self.atoms_layer_list[layer]
+        else:
+            raise ValueError("Invalid layer index for intralayer calculation.")
+        
+        # Perform the calculation using the assigned intra-layer calculator
+        atoms_L.calc = calc
+        calc.calculate(atoms_L)
+
+        # Update the results with energies and forces computed for this layer
+        lower_layers_num_atoms = sum([len(layer_atoms) for layer_atoms in self.atoms_layer_list[:layer]])
+        layer_atom_indices = [lower_layers_num_atoms, lower_layers_num_atoms + len(atoms_L)]
+        self.results['layer_energy'][layer, layer] = atoms_L.calc.results['energy']
+        self.results['layer_forces'][layer, layer][layer_atom_indices[0]:layer_atom_indices[1]] = atoms_L.calc.results['forces']
+
+    def calculate_interlayer(self, atoms, layer_1: int, layer_2: int):
+        """
+        Calculates inter-layer properties between two specified layers.
+
+        :param atoms: The ASE Atoms object.
+        :param layer_1: The index of the first layer.
+        :param layer_2: The index of the second layer.
+        """
+        if layer_2 <= layer_1 + 1:
+            # Combine atoms from both layers for the calculation
+            atoms_L = self.atoms_layer_list[layer_1].copy() + self.atoms_layer_list[layer_2].copy()
+            calc = self.inter_calc_list[layer_1]
+            atoms_L.calc = calc
+            calc.calculate(atoms_L)
+            # print(f"Unrelaxed from NLAYER NLAYER: Total_energy {atoms_L.calc.results['energy']:.3f} eV")
+            
+            # Update the results with energies and forces computed between these layers
+            lower_layers_num_atoms = sum([len(layer_atoms) for layer_atoms in self.atoms_layer_list[:layer_1]])
+            layer_atom_indices = [lower_layers_num_atoms, lower_layers_num_atoms + len(self.atoms_layer_list[layer_1]) + len(self.atoms_layer_list[layer_2])]
+            self.results['layer_energy'][layer_1, layer_2] = atoms_L.calc.results['energy']
+            self.results['layer_forces'][layer_1, layer_2][layer_atom_indices[0]:layer_atom_indices[1]] = atoms_L.calc.results['forces']
+
+    def get_atoms_layer_list(self, atoms):
+        """
+        Separates the provided atoms object into different layers based on the 'atom_types' array and layer_symbols.
+
+        :param atoms: The ASE Atoms object to be separated into layers.
+        """
+        for layer in range(len(self.intra_calc_list)):
+            # Determine the range of atom types for the current layer
+            lower_layer_num_atoms = sum([len(layer_atoms) for layer_atoms in self.layer_symbols[:layer]])
+            upper_layer_num_atoms = lower_layer_num_atoms + len(self.layer_symbols[layer]) - 1
+            
+            # Select atoms within the specified range of atom types
+            atoms_L = atoms.copy()[np.logical_and(atoms.arrays["atom_types"] <= upper_layer_num_atoms,
+                                                  atoms.arrays["atom_types"] >= lower_layer_num_atoms)]
+            
+            # Add the selected atoms to the layer list
+            self.atoms_layer_list.append(atoms_L)
+            


### PR DESCRIPTION
Vendors the stacked interlayer calculator helpers (`n_layer.py`, `macewrapper.py`) into `examples/interlayer_helpers/` so the MACE-interlayer → phonopy phonon workflow is self-contained. These provide the `NLayerCalculator` / `MACEWCalculator` used by `mlip_phonon_scattering`'s interlayer mode.

No ittnotify stub binary is shipped: torch 2.11 (NERSC `pytorch/2.11.0`) imports cleanly without it and `macewrapper`'s preload no-ops when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)